### PR TITLE
fix broken pacman behaviour

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -18,6 +18,7 @@ jobs:
     - name: build
       if: always()
       run: |
+        sed -i 's/DownloadUser/#DownloadUser/g' /etc/pacman.conf
         pacman -Syu --noconfirm base-devel strace patchelf curl wget \
           desktop-file-utils git artix-archlinux-support llvm mesa xorg-server-xvfb
         pacman-key --init && pacman-key --populate archlinux


### PR DESCRIPTION
https://archlinux.org/news/manual-intervention-for-pacman-700-and-local-repositories-required/

Wtf is this crap, instead of just being able to run pacman without root and then ask for elevated rights when needed Arch pushed this nonsense that breaks every single workflow that I have that uses Artix containers.



